### PR TITLE
Pass kid as an argument for to verifyCnf

### DIFF
--- a/rats.js
+++ b/rats.js
@@ -126,7 +126,7 @@ module.exports.verifyEAT = async (eat, fmt, kid = null) => {
             });
             // check cnf
             if (eat_object.cnf) {
-                let isValidCnf = verifyCnf(eat_object.cnf);
+                let isValidCnf = verifyCnf(eat_object.cnf, kid);
                 if (!isValidCnf) {
                     logger.error("cnf claim in EAT isn't valid.");
                 } else {


### PR DESCRIPTION
The kid extracted from TEEP Protocol wrapper should be passed to `verifyCnf` function.